### PR TITLE
fix: properly initialize stroke thickness

### DIFF
--- a/src/components/VueSignaturePad.vue
+++ b/src/components/VueSignaturePad.vue
@@ -183,14 +183,14 @@ watch(() => props.minWidth, (newVal) => {
     canvasOptions.value.minWidth = newVal
     canvasOptions.value.signaturePad.minWidth = newVal
   }
-})
+}, { immediate: true })
 
 watch(() => props.maxWidth, (newVal) => {
   if (newVal) {
     canvasOptions.value.maxWidth = newVal
     canvasOptions.value.signaturePad.maxWidth = newVal
   }
-})
+}, { immediate: true })
 
 watch(
   () => props.disabled,


### PR DESCRIPTION
**Describe the bug**
Unable to initialize the stroke thickness with the specified value; the initial value always seems to be 2.
 
**To Reproduce**

[![CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/p/devbox/h56wj3)

```vue
<script setup lang="ts">
import { VueSignaturePad } from "@selemondev/vue3-signature-pad"
import { ref } from "vue";

const initMinPenThickness = ref(2);
const initMaxPenThickness = ref(5);

</script>

<template>
  <div>
    Unable to initialize the stroke thickness with the specified value; the initial value always seems to be 2.
    <div style="border: 2px solid black;">
      <VueSignaturePad height="400px" width="1280px" :maxWidth="initMinPenThickness" :minWidth="initMaxPenThickness"
        :options="{ penColor: 'rgb(0, 0, 0)', backgroundColor: 'rgb(255,255,255)' }
          " />
    </div>
  </div>
</template>
```
 
 
**Expected behavior**
The stroke thickness should initialize to the specified value, not default to 2.
 
**Screenshots**
<img width="668" alt="image" src="https://github.com/user-attachments/assets/14a143be-a926-4d28-af8a-490d6089da17" />

**Result after bug fix**

[![CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/p/devbox/fix-vue3-signature-pad-bug-7r7zyv)