### PR TITLE
fix: VueSignaturePad component to pass backgroundColor properly to the signature_pad options

### DIFF
--- a/src/components/VueSignaturePad.vue
+++ b/src/components/VueSignaturePad.vue
@@ -39,10 +39,8 @@ const canvasOptions = ref<CanvasOptions>({
   minWidth: 2,
   maxWidth: 2,
   throttle: 16,
-  option: {
-    backgroundColor: 'rgb(255,255,255)',
-    penColor: 'rgb(0, 0, 0)',
-  },
+  backgroundColor: props.options.backgroundColor,
+  penColor: props.options.penColor,
   canvasUuid: `canvas${nanoid()}`,
 })
 
@@ -173,10 +171,10 @@ function draw() {
 
 watchEffect(() => {
   // Update penColor
-  canvasOptions.value.option.penColor = props.options.penColor
+  canvasOptions.value.penColor = props.options.penColor
   canvasOptions.value.signaturePad.penColor = props.options.penColor
   // Update backgroundColor
-  canvasOptions.value.option.backgroundColor = props.options.backgroundColor
+  canvasOptions.value.backgroundColor = props.options.backgroundColor
   canvasOptions.value.signaturePad.backgroundColor = props.options.backgroundColor
 })
 

--- a/src/components/VueSignaturePad.vue
+++ b/src/components/VueSignaturePad.vue
@@ -172,8 +172,12 @@ function draw() {
 }
 
 watchEffect(() => {
+  // Update penColor
   canvasOptions.value.option.penColor = props.options.penColor
   canvasOptions.value.signaturePad.penColor = props.options.penColor
+  // Update backgroundColor
+  canvasOptions.value.option.backgroundColor = props.options.backgroundColor
+  canvasOptions.value.signaturePad.backgroundColor = props.options.backgroundColor
 })
 
 watch(() => props.minWidth, (newVal) => {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -200,12 +200,11 @@ export interface Props {
   defaultUrl?: string
 }
 
-export interface CanvasOptions {
+export interface CanvasOptions extends Options {
   signaturePad: Signature
   throttle: number
   minWidth?: number
   maxWidth?: number
   dotSize?: number
-  option: Options
   canvasUuid: string
 }


### PR DESCRIPTION
fixes #30

@selemondev you might want to use [`defu`](https://github.com/unjs/defu) or smth similar to properly merge all your defaults, props and options together. As right now you are missing a step between `props` and `canvasOptions`.