### PR TITLE
chore: reduce bundle size ( shave off 1KB by implementing the functionality using built-in web APIs )

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
   },
   "dependencies": {
     "@selemondev/vue3-signature-pad": "^1.4.0",
-    "nanoid": "^5.0.9",
     "signature_pad": "^5.0.4"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,9 +11,6 @@ importers:
       '@selemondev/vue3-signature-pad':
         specifier: ^1.4.0
         version: 1.4.2(vue@3.5.21(typescript@5.9.2))
-      nanoid:
-        specifier: ^5.0.9
-        version: 5.1.6
       signature_pad:
         specifier: ^5.0.4
         version: 5.1.0

--- a/src/components/VueSignaturePad.vue
+++ b/src/components/VueSignaturePad.vue
@@ -8,7 +8,6 @@ import type {
   Signature,
   WaterMarkObj,
 } from '../types'
-import { nanoid } from 'nanoid'
 import SignaturePad from 'signature_pad'
 import { onBeforeUnmount, onMounted, ref, watch, watchEffect } from 'vue'
 
@@ -47,7 +46,7 @@ const canvasOptions = ref<CanvasOptions>({
   throttle: 16,
   backgroundColor: props.options.backgroundColor,
   penColor: props.options.penColor,
-  canvasUuid: `canvas${nanoid()}`,
+  canvasUuid: `canvas_${crypto.randomUUID()}`,
 })
 
 function isCanvasEmpty(): boolean {


### PR DESCRIPTION
This pull request is intended to reduce the bundle size ( shaving off 1KB ) by uninstalling `nanoid` and using the built in `crypto.randomUUID()` for the generation of uuids.