### PR TITLE
feat: add scaleOnResize prop to control canvas resizing behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ function handleUndo() {
 |        maxWidth   | `Number`      |         2                 | Maximum thickness of the pen line |
 |        minWidth   | `Number`      |         2                 | Minimum thickness of the pen line |
 |  clearOnResize  | `Boolean`     |          false          |Clear canvas on window resize|
+|  scaleOnResize  | `Boolean`     |          true          |When true, scales the signature image to fit new canvas dimensions on resize. When false, redraws using original stroke data without distortion (useful for orientation changes on mobile devices)|
 |  waterMark  | `Object`     |          {}          |Add addWaterMark |
 |  disabled  | `Boolean`     |          false          |Disable canvas |
 |  defaultUrl  | `String`     |          ""          |Show image by default |

--- a/src/components/VueSignaturePad.vue
+++ b/src/components/VueSignaturePad.vue
@@ -22,6 +22,7 @@ const props = withDefaults(defineProps<Props>(), {
     disabled: false,
     clearOnResize: false,
     defaultUrl: "",
+    scaleOnResize: true,
 });
 const emits = defineEmits<{
     (e: "beginStroke", val: Signature): void;
@@ -143,9 +144,14 @@ function resizeCanvas() {
     if (!c) return;
 
     let url: string | undefined;
+    let pointData: Point[][] | undefined;
 
     if (!isCanvasEmpty()) {
-        url = saveSignature();
+        if (props.scaleOnResize) {
+            url = saveSignature();
+        } else {
+            pointData = canvasOptions.value.signaturePad.toData();
+        }
     }
 
     const ratio = Math.max(window.devicePixelRatio || 1, 1);
@@ -164,8 +170,14 @@ function resizeCanvas() {
 
     clearCanvas();
 
-    if (!props.clearOnResize && url) {
-        fromDataURL(url);
+    if (!props.clearOnResize) {
+        if (props.scaleOnResize && url) {
+          
+            fromDataURL(url);
+        } else if (!props.scaleOnResize && pointData) {
+          
+            canvasOptions.value.signaturePad.fromData(pointData);
+        }
     }
 
     if (props.waterMark && Object.keys(props.waterMark).length) {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -209,6 +209,7 @@ export interface Props {
 	disabled?: boolean;
 	clearOnResize?: boolean;
 	defaultUrl?: string;
+	scaleOnResize?: boolean;
 }
 
 export interface CanvasOptions extends Options {


### PR DESCRIPTION
## Summary
Fixes #116

Adds a new `scaleOnResize` prop that gives users control over how signatures are handled during canvas resize (e.g., orientation changes on mobile).

## Changes
- Added `scaleOnResize` prop (default: `true` for backward compatibility)
- When `false`, uses stroke point data instead of data URL on resize, preventing distortion
- Updated README documentation

## Usage
```vue
<VueSignaturePad :scale-on-resize="false" />