### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/selemondev/vue3-signature-pad/security/code-scanning/6](https://github.com/selemondev/vue3-signature-pad/security/code-scanning/6)

To fix the issue, the workflow must explicitly declare the required `permissions` for either the entire workflow (root-level) or for each individual job. The best-practice minimal fix is to add a `permissions: contents: read` block at the top level of the workflow (just after the `name:` or `on:` keys). This ensures all jobs default to read-only access to repository contents, tightly restricting GITHUB_TOKEN capabilities and following the principle of least privilege. No functional changes will occur for jobs that do not need write permissions; if some jobs do need write permissions, those would require an explicit override at the job level. In this patch, we are only allowed to edit what is in the provided snippet.

Changes required:  
- Insert the following block after the `name: CI` line and before the `on:` block:  
  ```yaml
  permissions:
    contents: read
  ```

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow configuration for improved security controls.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->