### PR TITLE
refactor: peer dependencies semver versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
 	},
 	"devDependencies": {
 		"@biomejs/biome": "2.3.10",
-		"@vue/tsconfig": "^0.7.0",
+		"@vue/tsconfig": "^0.8.0",
 		"shiki": "^3.21.0",
 		"tsdown": "0.20.0-beta.3",
 		"typescript": "5.8.3",
@@ -53,7 +53,7 @@
 		"vue-tsc": "^3.1.0"
 	},
 	"peerDependencies": {
-		"@vue/tsconfig": "^0.7.0",
+		"@vue/tsconfig": "^0.8.0",
 		"vue": "^3.5.17",
 		"vue-tsc": "^3.1.0"
 	}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,8 +37,8 @@ importers:
         specifier: 2.3.10
         version: 2.3.10
       '@vue/tsconfig':
-        specifier: ^0.7.0
-        version: 0.7.0(typescript@5.8.3)(vue@3.5.26(typescript@5.8.3))
+        specifier: ^0.8.0
+        version: 0.8.1(typescript@5.8.3)(vue@3.5.26(typescript@5.8.3))
       shiki:
         specifier: ^3.21.0
         version: 3.21.0
@@ -1686,8 +1686,8 @@ packages:
   '@vue/shared@3.5.26':
     resolution: {integrity: sha512-7Z6/y3uFI5PRoKeorTOSXKcDj0MSasfNNltcslbFrPpcw6aXRUALq4IfJlaTRspiWIUOEZbrpM+iQGmCOiWe4A==}
 
-  '@vue/tsconfig@0.7.0':
-    resolution: {integrity: sha512-ku2uNz5MaZ9IerPPUyOHzyjhXoX2kVJaVf7hL315DC17vS6IiZRmmCPfggNbU16QTvM80+uYYy3eYJB59WCtvg==}
+  '@vue/tsconfig@0.8.1':
+    resolution: {integrity: sha512-aK7feIWPXFSUhsCP9PFqPyFOcz4ENkb8hZ2pneL6m2UjCkccvaOhC/5KCKluuBufvp2KzkbdA2W2pk20vLzu3g==}
     peerDependencies:
       typescript: 5.x
       vue: ^3.4.0
@@ -5049,7 +5049,7 @@ snapshots:
 
   '@vue/shared@3.5.26': {}
 
-  '@vue/tsconfig@0.7.0(typescript@5.8.3)(vue@3.5.26(typescript@5.8.3))':
+  '@vue/tsconfig@0.8.1(typescript@5.8.3)(vue@3.5.26(typescript@5.8.3))':
     optionalDependencies:
       typescript: 5.8.3
       vue: 3.5.26(typescript@5.8.3)


### PR DESCRIPTION
Closes #152 

This pull request is intended to close issue #152 by updating the `@vue/tsconfig` version to v0.8.0 which will now accept any version between v0.8.0 and v0.9.0 so as to get rid of the unmet peer dependencies error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Vue TypeScript configuration dependency to the latest compatible version.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->