### PR TITLE
refactor: stretching lines when using prop options

### DIFF
--- a/src/components/VueSignaturePad.vue
+++ b/src/components/VueSignaturePad.vue
@@ -12,8 +12,8 @@ import type {
 let canvas: HTMLCanvasElement;
 const props = withDefaults(defineProps<Props>(), {
 	throttle: 16,
-	minWidth: 5,
-	maxWidth: 5,
+	minWidth: 2,
+	maxWidth: 2,
 	height: "100%",
 	width: "100%",
 	options: () => ({
@@ -34,9 +34,9 @@ const emits = defineEmits<{
 const canvasOptions = ref<CanvasOptions>({
 	signaturePad: {} as Signature,
 	dotSize: 0.5,
-	minWidth: 2,
-	maxWidth: 2,
-	throttle: 16,
+	minWidth: props.minWidth,
+	maxWidth: props.maxWidth,
+	throttle: props.throttle,
 	backgroundColor: props.options.backgroundColor,
 	penColor: props.options.penColor,
 	canvasUuid: `canvas_${crypto.randomUUID()}`,


### PR DESCRIPTION
Fixes initialize properties mismatch when externally supply properties (pen and background colors) that cause line stretching

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted the default pen stroke width for the signature pad, resulting in a thinner drawing experience.
  * Signature pad sizing now follows the selected settings more consistently, including width and stroke timing options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->